### PR TITLE
feat: add hover anchor links to markdown headings

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -103,23 +103,4 @@
   pre > code {
     @apply rounded-md p-6!;
   }
-
-  /* Heading anchor links */
-  .heading-with-anchor {
-    @apply relative;
-  }
-
-  .heading-with-anchor::before {
-    content: '';
-    @apply absolute -left-8 top-0 w-8 h-full;
-  }
-
-  .heading-with-anchor .anchor-link {
-    @apply text-sm font-normal no-underline;
-  }
-
-  .heading-with-anchor:hover .anchor-link,
-  .heading-with-anchor .anchor-link:hover {
-    @apply opacity-100;
-  }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -103,4 +103,13 @@
   pre > code {
     @apply rounded-md p-6!;
   }
+
+  /* Heading anchor links */
+  .heading-with-anchor .anchor-link {
+    @apply text-sm font-normal no-underline;
+  }
+
+  .heading-with-anchor:hover .anchor-link {
+    @apply opacity-100;
+  }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -105,11 +105,21 @@
   }
 
   /* Heading anchor links */
+  .heading-with-anchor {
+    @apply relative;
+  }
+
+  .heading-with-anchor::before {
+    content: '';
+    @apply absolute -left-8 top-0 w-8 h-full;
+  }
+
   .heading-with-anchor .anchor-link {
     @apply text-sm font-normal no-underline;
   }
 
-  .heading-with-anchor:hover .anchor-link {
+  .heading-with-anchor:hover .anchor-link,
+  .heading-with-anchor .anchor-link:hover {
     @apply opacity-100;
   }
 }

--- a/src/services/html/index.test.ts
+++ b/src/services/html/index.test.ts
@@ -4,7 +4,7 @@ import { escapeHtml, createSlug } from "./index";
 describe("escapeHtml", () => {
   it("should escape basic HTML characters", () => {
     const input = '<script>alert("xss")</script>';
-    const expected = '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;';
+    const expected = "&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;";
     expect(escapeHtml(input)).toBe(expected);
   });
 
@@ -26,7 +26,6 @@ describe("escapeHtml", () => {
     expect(escapeHtml(input)).toBe(expected);
   });
 
-
   it("should handle empty string", () => {
     expect(escapeHtml("")).toBe("");
   });
@@ -43,7 +42,8 @@ describe("escapeHtml", () => {
 
   it("should escape multiple instances of the same character", () => {
     const input = '"""&&&<<<>>>';
-    const expected = '&quot;&quot;&quot;&amp;&amp;&amp;&lt;&lt;&lt;&gt;&gt;&gt;';
+    const expected =
+      "&quot;&quot;&quot;&amp;&amp;&amp;&lt;&lt;&lt;&gt;&gt;&gt;";
     expect(escapeHtml(input)).toBe(expected);
   });
 
@@ -53,13 +53,13 @@ describe("escapeHtml", () => {
       'javascript:alert("xss")',
       '<svg onload="alert(1)">',
       '"><script>alert("xss")</script>',
-      "';alert('xss');//"
+      "';alert('xss');//",
     ];
 
-    xssAttempts.forEach(xss => {
+    xssAttempts.forEach((xss) => {
       const result = escapeHtml(xss);
-      expect(result).not.toContain('<');
-      expect(result).not.toContain('>');
+      expect(result).not.toContain("<");
+      expect(result).not.toContain(">");
       expect(result).not.toContain('"');
       expect(result).not.toContain("'");
     });
@@ -89,8 +89,8 @@ describe("createSlug", () => {
     const result = createSlug(input);
     expect(result).not.toContain('"');
     expect(result).not.toContain("'");
-    expect(result).not.toContain('<');
-    expect(result).not.toContain('>');
+    expect(result).not.toContain("<");
+    expect(result).not.toContain(">");
   });
 
   it("should handle all HTML entities", () => {
@@ -111,7 +111,6 @@ describe("createSlug", () => {
   it("should handle empty string", () => {
     expect(createSlug("")).toBe("");
   });
-
 
   it("should handle special characters and symbols", () => {
     const input = "Hello@World#Test$";
@@ -140,13 +139,13 @@ describe("createSlug", () => {
       'javascript:alert("xss")',
       '<img src="x" onerror="alert(1)">',
       '"><script>alert("xss")</script>',
-      "';alert('xss');//"
+      "';alert('xss');//",
     ];
 
-    xssAttempts.forEach(xss => {
+    xssAttempts.forEach((xss) => {
       const result = createSlug(xss);
-      expect(result).not.toContain('<');
-      expect(result).not.toContain('>');
+      expect(result).not.toContain("<");
+      expect(result).not.toContain(">");
       expect(result).not.toContain('"');
       expect(result).not.toContain("'");
     });

--- a/src/services/html/index.test.ts
+++ b/src/services/html/index.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { escapeHtml } from "./index";
+
+describe("escapeHtml", () => {
+  it("should escape basic HTML characters", () => {
+    const input = '<script>alert("xss")</script>';
+    const expected = '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;';
+    expect(escapeHtml(input)).toBe(expected);
+  });
+
+  it("should escape ampersand characters", () => {
+    const input = "Tom & Jerry";
+    const expected = "Tom &amp; Jerry";
+    expect(escapeHtml(input)).toBe(expected);
+  });
+
+  it("should escape quotes", () => {
+    const input = `He said "Hello" and she said 'Hi'`;
+    const expected = "He said &quot;Hello&quot; and she said &#x27;Hi&#x27;";
+    expect(escapeHtml(input)).toBe(expected);
+  });
+
+  it("should escape all dangerous characters together", () => {
+    const input = `<div class="test" data-value='&"'>Content</div>`;
+    const expected = `&lt;div class=&quot;test&quot; data-value=&#x27;&amp;&quot;&#x27;&gt;Content&lt;/div&gt;`;
+    expect(escapeHtml(input)).toBe(expected);
+  });
+
+  it("should return empty string for non-string input", () => {
+    expect(escapeHtml(null as any)).toBe("");
+    expect(escapeHtml(undefined as any)).toBe("");
+    expect(escapeHtml(123 as any)).toBe("");
+    expect(escapeHtml({} as any)).toBe("");
+    expect(escapeHtml([] as any)).toBe("");
+  });
+
+  it("should handle empty string", () => {
+    expect(escapeHtml("")).toBe("");
+  });
+
+  it("should handle normal text without special characters", () => {
+    const input = "Hello World";
+    expect(escapeHtml(input)).toBe("Hello World");
+  });
+
+  it("should handle text with numbers and symbols", () => {
+    const input = "Price: $100 + tax";
+    expect(escapeHtml(input)).toBe("Price: $100 + tax");
+  });
+
+  it("should escape multiple instances of the same character", () => {
+    const input = '"""&&&<<<>>>';
+    const expected = '&quot;&quot;&quot;&amp;&amp;&amp;&lt;&lt;&lt;&gt;&gt;&gt;';
+    expect(escapeHtml(input)).toBe(expected);
+  });
+
+  it("should handle potential XSS attack vectors", () => {
+    const xssAttempts = [
+      '<img src="x" onerror="alert(1)">',
+      'javascript:alert("xss")',
+      '<svg onload="alert(1)">',
+      '"><script>alert("xss")</script>',
+      "';alert('xss');//"
+    ];
+
+    xssAttempts.forEach(xss => {
+      const result = escapeHtml(xss);
+      expect(result).not.toContain('<');
+      expect(result).not.toContain('>');
+      expect(result).not.toContain('"');
+      expect(result).not.toContain("'");
+    });
+  });
+});

--- a/src/services/html/index.ts
+++ b/src/services/html/index.ts
@@ -1,7 +1,7 @@
 /**
  * HTML属性値を安全にエスケープする
  * XSS攻撃を防ぐために危険な文字をHTMLエンティティに変換
- * 
+ *
  * @param unsafe エスケープする文字列
  * @returns エスケープされた安全な文字列
  */
@@ -17,21 +17,21 @@ export function escapeHtml(unsafe: string): string {
 /**
  * テキストをURL安全なslugに変換する
  * セキュリティを考慮してHTML属性として安全な文字列を生成
- * 
+ *
  * @param text 変換するテキスト
  * @returns URL安全なslug文字列
  */
 export function createSlug(text: string): string {
   // HTMLエンティティをデコードしてからエンコード
   const cleanText = text
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
     .replace(/&quot;/g, '"')
     .replace(/&#x27;/g, "'");
-  
+
   // percent encodeして、さらにHTML属性として危険な文字をフィルタ
   return encodeURIComponent(cleanText)
-    .replace(/['"<>]/g, '') // HTML属性として危険な文字を除去
+    .replace(/['"<>]/g, "") // HTML属性として危険な文字を除去
     .substring(0, 100); // 長さ制限
 }

--- a/src/services/html/index.ts
+++ b/src/services/html/index.ts
@@ -6,14 +6,32 @@
  * @returns エスケープされた安全な文字列
  */
 export function escapeHtml(unsafe: string): string {
-  if (typeof unsafe !== 'string') {
-    return '';
-  }
-
   return unsafe
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#x27;");
+}
+
+/**
+ * テキストをURL安全なslugに変換する
+ * セキュリティを考慮してHTML属性として安全な文字列を生成
+ * 
+ * @param text 変換するテキスト
+ * @returns URL安全なslug文字列
+ */
+export function createSlug(text: string): string {
+  // HTMLエンティティをデコードしてからエンコード
+  const cleanText = text
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#x27;/g, "'");
+  
+  // percent encodeして、さらにHTML属性として危険な文字をフィルタ
+  return encodeURIComponent(cleanText)
+    .replace(/['"<>]/g, '') // HTML属性として危険な文字を除去
+    .substring(0, 100); // 長さ制限
 }

--- a/src/services/html/index.ts
+++ b/src/services/html/index.ts
@@ -1,0 +1,19 @@
+/**
+ * HTML属性値を安全にエスケープする
+ * XSS攻撃を防ぐために危険な文字をHTMLエンティティに変換
+ * 
+ * @param unsafe エスケープする文字列
+ * @returns エスケープされた安全な文字列
+ */
+export function escapeHtml(unsafe: string): string {
+  if (typeof unsafe !== 'string') {
+    return '';
+  }
+
+  return unsafe
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;");
+}

--- a/src/services/markdown/extensions/heading.ts
+++ b/src/services/markdown/extensions/heading.ts
@@ -1,4 +1,5 @@
 import { MarkedExtension, Tokens } from "marked";
+import { escapeHtml } from "../../html";
 
 /**
  * テキストをURL安全なslugに変換する
@@ -23,17 +24,6 @@ function createSlug(text: string): string {
  * カスタムヘディングレンダラー
  * ホバー時にアンカーリンクを表示するヘディングを生成する
  */
-/**
- * HTML属性値を安全にエスケープ
- */
-function escapeHtml(unsafe: string): string {
-  return unsafe
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#x27;");
-}
 
 export const customHeadingExtension: MarkedExtension = {
   renderer: {

--- a/src/services/markdown/extensions/heading.ts
+++ b/src/services/markdown/extensions/heading.ts
@@ -43,9 +43,9 @@ export const customHeadingExtension: MarkedExtension = {
       const escapedSlug = escapeHtml(slug);
       
       return `
-        <${tag} id="${escapedSlug}" class="heading-with-anchor group relative">
+        <${tag} id="${escapedSlug}" class="group relative before:content-[''] before:absolute before:-left-8 before:top-0 before:w-8 before:h-full">
           ${text}
-          <a href="#${escapedSlug}" class="anchor-link opacity-0 group-hover:opacity-100 transition-opacity duration-200 absolute -left-6 top-1/2 -translate-y-1/2 text-gray-400 hover:text-primary no-underline" aria-label="この見出しへのリンク">
+          <a href="#${escapedSlug}" class="opacity-0 group-hover:opacity-100 hover:opacity-100 transition-opacity duration-200 absolute -left-6 top-1/2 -translate-y-1/2 text-gray-400 hover:text-primary no-underline text-sm font-normal" aria-label="この見出しへのリンク">
             #
           </a>
         </${tag}>

--- a/src/services/markdown/extensions/heading.ts
+++ b/src/services/markdown/extensions/heading.ts
@@ -1,24 +1,5 @@
 import { MarkedExtension, Tokens } from "marked";
-import { escapeHtml } from "../../html";
-
-/**
- * テキストをURL安全なslugに変換する
- * セキュリティを考慮してHTML属性として安全な文字列を生成
- */
-function createSlug(text: string): string {
-  // HTMLエンティティをデコードしてからエンコード
-  const cleanText = text
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#x27;/g, "'");
-  
-  // percent encodeして、さらにHTML属性として危険な文字をフィルタ
-  return encodeURIComponent(cleanText)
-    .replace(/['"<>]/g, '') // HTML属性として危険な文字を除去
-    .substring(0, 100); // 長さ制限
-}
+import { escapeHtml, createSlug } from "../../html";
 
 /**
  * カスタムヘディングレンダラー
@@ -28,10 +9,10 @@ function createSlug(text: string): string {
 export const customHeadingExtension: MarkedExtension = {
   renderer: {
     heading({ text, depth }: Tokens.Heading): string {
-      const slug = createSlug(text);
       const tag = `h${depth}`;
+      const slug = createSlug(text);
       const escapedSlug = escapeHtml(slug);
-      
+
       return `
         <${tag} id="${escapedSlug}" class="group relative before:content-[''] before:absolute before:-left-8 before:top-0 before:w-8 before:h-full">
           ${text}

--- a/src/services/markdown/extensions/heading.ts
+++ b/src/services/markdown/extensions/heading.ts
@@ -45,7 +45,7 @@ export const customHeadingExtension: MarkedExtension = {
       return `
         <${tag} id="${escapedSlug}" class="heading-with-anchor group relative">
           ${text}
-          <a href="#${escapedSlug}" class="anchor-link opacity-0 group-hover:opacity-100 transition-opacity duration-200 absolute -left-6 top-0 text-gray-400 hover:text-primary no-underline" aria-label="この見出しへのリンク">
+          <a href="#${escapedSlug}" class="anchor-link opacity-0 group-hover:opacity-100 transition-opacity duration-200 absolute -left-6 top-1/2 -translate-y-1/2 text-gray-400 hover:text-primary no-underline" aria-label="この見出しへのリンク">
             #
           </a>
         </${tag}>

--- a/src/services/markdown/extensions/heading.ts
+++ b/src/services/markdown/extensions/heading.ts
@@ -1,0 +1,55 @@
+import { MarkedExtension, Tokens } from "marked";
+
+/**
+ * テキストをURL安全なslugに変換する
+ * セキュリティを考慮してHTML属性として安全な文字列を生成
+ */
+function createSlug(text: string): string {
+  // HTMLエンティティをデコードしてからエンコード
+  const cleanText = text
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#x27;/g, "'");
+  
+  // percent encodeして、さらにHTML属性として危険な文字をフィルタ
+  return encodeURIComponent(cleanText)
+    .replace(/['"<>]/g, '') // HTML属性として危険な文字を除去
+    .substring(0, 100); // 長さ制限
+}
+
+/**
+ * カスタムヘディングレンダラー
+ * ホバー時にアンカーリンクを表示するヘディングを生成する
+ */
+/**
+ * HTML属性値を安全にエスケープ
+ */
+function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;");
+}
+
+export const customHeadingExtension: MarkedExtension = {
+  renderer: {
+    heading({ text, depth }: Tokens.Heading): string {
+      const slug = createSlug(text);
+      const tag = `h${depth}`;
+      const escapedSlug = escapeHtml(slug);
+      
+      return `
+        <${tag} id="${escapedSlug}" class="heading-with-anchor group relative">
+          ${text}
+          <a href="#${escapedSlug}" class="anchor-link opacity-0 group-hover:opacity-100 transition-opacity duration-200 absolute -left-6 top-0 text-gray-400 hover:text-primary no-underline" aria-label="この見出しへのリンク">
+            #
+          </a>
+        </${tag}>
+      `;
+    },
+  },
+};

--- a/src/services/markdown/index.ts
+++ b/src/services/markdown/index.ts
@@ -2,6 +2,7 @@ import { Marked } from "marked";
 import { customCodeExtension } from "./extensions/code";
 import { messageBoxExtension } from "./extensions/messageBox";
 import { customLinkExtension } from "./extensions/link";
+import { customHeadingExtension } from "./extensions/heading";
 
 let instance: Marked | undefined = undefined;
 
@@ -14,6 +15,7 @@ export function getMarkedInstance() {
     const _instance = new Marked();
     _instance.use(customLinkExtension);
     _instance.use(customCodeExtension);
+    _instance.use(customHeadingExtension);
     _instance.use({
       extensions: [messageBoxExtension],
     });


### PR DESCRIPTION
## Summary
- マークダウンのヘッドライン（h1-h6）にホバー時にアンカーリンクを表示する機能を追加
- ヘッドラインにマウスホバーすると左側に「#」が表示され、クリックでページ内ジャンプが可能
- セキュリティを考慮した安全な実装

## 実装内容
- 新しいmarked.js拡張 `customHeadingExtension` を作成
- パーセントエンコードとHTMLエスケープによる安全なslug生成
- CSS でスムーズなホバー体験を実現
- アンカーリンクの垂直中央配置

## Test plan
- [ ] ヘッドラインにマウスホバーで「#」が表示されることを確認
- [ ] アンカーリンクをクリックして該当ヘッドラインにジャンプできることを確認
- [ ] 日本語ヘッドラインでも正常に動作することを確認
- [ ] モバイル表示での動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)